### PR TITLE
CMake fixes and tweaks

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,10 +1,10 @@
 find_package(PkgConfig REQUIRED)
-pkg_check_modules(EventdEvent REQUIRED libeventd-event>=0.3)
+pkg_check_modules(Eventd REQUIRED libeventd>=0.4)
 pkg_check_modules(EventdPlugin REQUIRED libeventd-plugin>=0.3)
 pkg_check_modules(SystemdJournal REQUIRED libsystemd-journal)
 
 include_directories(SYSTEM
-    ${EventdEvent_INCLUDE_DIRS}
+    ${Eventd_INCLUDE_DIRS}
     ${EventdPlugin_INCLUDE_DIRS}
     ${SystemdJournal_INCLUDE_DIRS})
 
@@ -15,7 +15,7 @@ target_compile_definitions(journald
         -DG_LOG_DOMAIN="eventd-journald")
 target_link_libraries(journald
     PRIVATE
-        ${EventdEvent_LIBRARIES}
+        ${Eventd_LIBRARIES}
         ${EventdPlugin_LIBRARIES}
         ${SystemdJournal_LIBRARIES})
 set_target_properties(journald

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,17 @@ pkg_check_modules(Eventd REQUIRED libeventd>=0.4)
 pkg_check_modules(EventdPlugin REQUIRED libeventd-plugin>=0.3)
 pkg_check_modules(SystemdJournal REQUIRED libsystemd-journal)
 
+macro (pkg_get_variable pkg var out)
+    execute_process(COMMAND ${PKG_CONFIG_EXECUTABLE} --variable=${var} ${pkg}
+        OUTPUT_VARIABLE ${out}
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
+endmacro ()
+
+pkg_get_variable(libeventd pkglibdir eventd_pkglibdir)
+find_library(EventdHelpers_LIBRARY eventd-helpers
+    PATHS ${eventd_pkglibdir}
+    NO_DEFAULT_PATH)
+
 include_directories(SYSTEM
     ${Eventd_INCLUDE_DIRS}
     ${EventdPlugin_INCLUDE_DIRS}
@@ -17,6 +28,7 @@ target_link_libraries(journald
     PRIVATE
         ${Eventd_LIBRARIES}
         ${EventdPlugin_LIBRARIES}
+        ${EventdHelpers_LIBRARY}
         ${SystemdJournal_LIBRARIES})
 set_target_properties(journald
     PROPERTIES

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,7 +35,18 @@ set_target_properties(journald
         PREFIX    ""
         NO_SONAME 1)
 
+pkg_get_variable(libeventd-plugin exec_prefix eventdplugin_execprefix)
+if (NOT CMAKE_INSTALL_PREFIX STREQUAL eventdplugin_execprefix)
+  message(FATAL_ERROR "CMAKE_INSTALL_PREFIX does not match libeventd-plugin's exec-prefix (${eventdplugin_execprefix}); this is not supported")
+endif ()
+
+pkg_get_variable(libeventd-plugin pluginsdir eventdplugin_pluginsdir)
+set(EVENTD_PLUGINS_DIR ${eventdplugin_pluginsdir}
+    CACHE
+    PATH
+    "eventd plugins directory (defaults to ${eventdplugin_pluginsdir}")
+
 install(
     TARGETS     journald
-    DESTINATION lib${LIB_SUFFIX}/eventd/plugins
+    DESTINATION ${EVENTD_PLUGINS_DIR}
     COMPONENT   runtime)

--- a/src/journald.c
+++ b/src/journald.c
@@ -21,8 +21,8 @@
 #include <glib-object.h>
 #include <glib-unix.h>
 
-#include <libeventd-config.h>
 #include <libeventd-event.h>
+#include <libeventd-helpers-config.h>
 #include <eventd-plugin.h>
 
 #include <systemd/sd-journal.h>
@@ -338,13 +338,13 @@ _eventd_journald_global_parse(EventdPluginContext *context, GKeyFile *config_fil
     if (!g_key_file_has_group(config_file, "Journald"))
         return;
 
-    if (libeventd_config_key_file_get_boolean(config_file, "Journald", "LocalOnly", &local_only) < 0) {
+    if (evhelpers_config_key_file_get_boolean(config_file, "Journald", "LocalOnly", &local_only) < 0) {
         context->local_only = TRUE;
     } else {
         context->local_only = local_only;
     }
 
-    libeventd_config_key_file_get_string_list(config_file, "Journald", "Journals", &journals, NULL);
+    evhelpers_config_key_file_get_string_list(config_file, "Journald", "Journals", &journals, NULL);
 
     if (journals) {
         gchar **journal_iter = journals;
@@ -380,7 +380,7 @@ _eventd_journald_global_parse(EventdPluginContext *context, GKeyFile *config_fil
     if (!context->journals)
         g_warning("not watching any journals");
 
-    libeventd_config_key_file_get_string_list(config_file, "Journald", "Events", &events, NULL);
+    evhelpers_config_key_file_get_string_list(config_file, "Journald", "Events", &events, NULL);
 
     if (events) {
         gchar **event_iter = events;


### PR DESCRIPTION
The first commit is a necessary fix for the [renames I did in eventd](https://github.com/sardemff7/eventd/compare/7d1806243404bb2d69465a7ee6894e0c33dbe8b8...ff98df96485fcb6cf3082fec8d1207b5dcc4c705).

Second one is for proper linking.
With `-Wl,--no-undefined` your plugin fails to link, because `evhelpers_*` functions are undefined.

Third one is to install your plugin exactly where eventd is expecting it.
The `pluginsdir` variable in `libeventd-plugin.pc` is provided exactly for that purpose, so let’s just use it!
